### PR TITLE
This adds a note about dictionaries in Python 3.7 being ordered by default

### DIFF
--- a/13-Advanced Python Modules/01-Collections Module.ipynb
+++ b/13-Advanced Python Modules/01-Collections Module.ipynb
@@ -392,6 +392,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "**Note:** As of Python 3.7, dictionaries are now ordered by key insertion by default, as [explained in the official Python documentation — What’s New In Python 3.7](https://docs.python.org/3/whatsnew/3.7.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Equality with an Ordered Dictionary\n",
     "A regular dict looks at its contents when testing for equality. An OrderedDict also considers the order the items were added.\n",
     "\n",


### PR DESCRIPTION
Hello there!

As [announced by Guido himself](https://mail.python.org/pipermail/python-dev/2017-December/151283.html), Python 3.7 now has ordered dictionaries by default.