### PR TITLE
Set up player's chips before game starts

### DIFF
--- a/08-Milestone Project - 2/03-Milestone Project 2 - Complete Walkthrough Solution.ipynb
+++ b/08-Milestone Project - 2/03-Milestone Project 2 - Complete Walkthrough Solution.ipynb
@@ -698,6 +698,9 @@
     }
    ],
    "source": [
+    "# Set up the Player's chips\n",
+    "player_chips = Chips()  # remember the default value is 100    \n",
+    "\n",
     "while True:\n",
     "    # Print an opening statement\n",
     "    print('Welcome to BlackJack! Get as close to 21 as you can without going over!\\n\\\n",
@@ -715,9 +718,6 @@
     "    dealer_hand.add_card(deck.deal())\n",
     "    dealer_hand.add_card(deck.deal())\n",
     "            \n",
-    "    # Set up the Player's chips\n",
-    "    player_chips = Chips()  # remember the default value is 100    \n",
-    "    \n",
     "    # Prompt the Player for their bet\n",
     "    take_bet(player_chips)\n",
     "    \n",


### PR DESCRIPTION
If you don't do this, every time the player restarts the game they have the same number of chips (100), but if you set up their chips before the game starts, if they wish to continue playing they can keep a running total of their chips.