### PR TITLE
Add "Try in a Jupyter notebook" button

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ Get it now for 95% off with the link:
 https://www.udemy.com/complete-python-bootcamp/?couponCode=COMPLETE_GITHUB
 
 Thanks!
+
+[![Deepnote](https://deepnote.com/buttons/try-in-a-jupyter-notebook-small.svg)](https://deepnote.com/launch?url=https%3A%2F%2Fgithub.com%2FPierian-Data%2FComplete-Python-3-Bootcamp%2Fblob%2Fmaster%2F00-Python%2520Object%2520and%2520Data%2520Structure%2520Basics%2F01-Numbers.ipynb)


### PR DESCRIPTION
Hi there, I'm Dan from Deepnote. We're a small startup working on a new collaborative data science notebook, compatible with Jupyter. I was trying out Deepnote with your bootcamp notebooks and I thought it might be useful for others too to have a one-click button to run them, so I submitted a PR.
Hope you find it useful!

Thanks for your work,
Dan