### PR TITLE
Nit: Change "premission" to "permission" for language consistency.

### DIFF
--- a/13-Web-Scraping/.ipynb_checkpoints/00-Guide-to-Web-Scraping-checkpoint.ipynb
+++ b/13-Web-Scraping/.ipynb_checkpoints/00-Guide-to-Web-Scraping-checkpoint.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "Let's get you started with web scraping and Python. Before we begin, here are some important rules to follow and understand:\n",
     "\n",
-    "1. Always be respectful and try to get premission to scrape, do not bombard a website with scraping requests, otherwise your IP address may be blocked!\n",
+    "1. Always be respectful and try to get permission to scrape, do not bombard a website with scraping requests, otherwise your IP address may be blocked!\n",
     "2. Be aware that websites change often, meaning your code could go from working to totally broken from one day to the next.\n",
     "3. Pretty much every web scraping project of interest is a unique and custom job, so try your best to generalize the skills learned here.\n",
     "\n",

--- a/13-Web-Scraping/00-Guide-to-Web-Scraping.ipynb
+++ b/13-Web-Scraping/00-Guide-to-Web-Scraping.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "Let's get you started with web scraping and Python. Before we begin, here are some important rules to follow and understand:\n",
     "\n",
-    "1. Always be respectful and try to get premission to scrape, do not bombard a website with scraping requests, otherwise your IP address may be blocked!\n",
+    "1. Always be respectful and try to get permission to scrape, do not bombard a website with scraping requests, otherwise your IP address may be blocked!\n",
     "2. Be aware that websites change often, meaning your code could go from working to totally broken from one day to the next.\n",
     "3. Pretty much every web scraping project of interest is a unique and custom job, so try your best to generalize the skills learned here.\n",
     "\n",


### PR DESCRIPTION
This PR addresses a minor typo in the documentation/markdown cell, correcting 'premission' to 'permission'