### PR TITLE
Feat: qBittorrent+ProtonVPN for ARM64, port 9090

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,79 @@
+# Environment variables
+.env
+*.env.local
+*.env.*.local
+
+# Docker & Project specific
+docker-compose.override.yml
+docker-compose.local.yml
+
+# Sensitive or large directories that should not be committed
+downloads/
+# If you were using bind mounts for configuration data instead of named Docker volumes,
+# you would uncomment lines like these:
+# qbittorrent_config/
+# protonvpn_data/
+
+# Python specific
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+.Python
+build/
+develop-eggs/
+dist/
+# downloads/ # Already covered above, but good to be explicit if it were Python-specific downloads
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.manifest
+*.spec
+pip-log.txt
+pip-delete-this-directory.txt
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.log
+.hypothesis/
+.pytest_cache/
+celerybeat-schedule
+
+# IDE / Editor specific files
+.vscode/
+.idea/
+*.project
+*.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.swp
+*.swo
+*~
+
+# Jupyter Notebook checkpoints
+.ipynb_checkpoints/
+
+# Operating System files
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
+# Compiled files / Output directories
+/out/
+/bin/
+/obj/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,157 @@
-# Complete-Python-3-Bootcamp
-Course Files for Complete Python 3 Bootcamp Course on Udemy
+# qBittorrent with ProtonVPN via Docker Compose (ARM64 Ready)
 
+This project sets up qBittorrent to run through a ProtonVPN connection using Docker Compose. All qBittorrent traffic will be routed through the VPN. This setup is optimized for ARM64 devices like the Raspberry Pi (4B, 5, etc.) but will also work on x86-64 architectures.
 
-Get it now for 95% off with the link:
-https://www.udemy.com/complete-python-bootcamp/?couponCode=COMPLETE_GITHUB
+## Features
 
-Thanks!
+-   **Secure Torrenting:** All qBittorrent traffic is routed through ProtonVPN.
+-   **ARM64 Compatible:** Designed to work on Raspberry Pi and other ARM64 devices. Also compatible with x86-64.
+-   **qBittorrent Web UI on Port 9090:** Access qBittorrent remotely.
+-   **Easy Configuration:** Primarily via a simple `.env` file for your ProtonVPN credentials.
+-   **Persistent Configuration:** qBittorrent settings are saved in a Docker volume.
+-   **Local Download Directory:** Maps to a `./downloads` folder on your host.
+-   **Healthcheck:** Ensures qBittorrent only starts/runs when the VPN is confirmed active.
+-   **Kill Switch:** If the VPN container stops, qBittorrent loses network access.
+
+## Prerequisites
+
+-   Docker: [Install Docker](https://docs.docker.com/get-docker/)
+-   Docker Compose: [Install Docker Compose](https://docs.docker.com/compose/install/) (usually included with Docker Desktop or installed via pip)
+-   A ProtonVPN account (free or paid).
+    -   You need your **OpenVPN/IKEv2 username and password**. Find these by logging into your ProtonVPN account at [account.protonvpn.com/account](https://account.protonvpn.com/account) and navigating to `Account -> OpenVPN/IKEv2 username`.
+
+## "Plug and Play" Setup
+
+The goal is to make this as close to "plug and play" as possible after providing your ProtonVPN credentials.
+
+1.  **Clone the Repository or Download Files:**
+    ```bash
+    # Example if you have git installed
+    # git clone <repository_url>
+    # cd <repository_name>
+    # If downloaded, extract and navigate to the project directory
+    ```
+
+2.  **Create `.env` File for Credentials:**
+    Copy the provided `example.env` file to `.env`:
+    ```bash
+    cp example.env .env
+    ```
+    Now, **edit the `.env` file** with your ProtonVPN OpenVPN/IKEv2 username and password:
+    ```dotenv
+    # .env
+    PROTONVPN_USERNAME=your_protonvpn_openvpn_username
+    PROTONVPN_PASSWORD=your_protonvpn_openvpn_password
+
+    # Optional: Specify a ProtonVPN server (e.g., NL-FREE#1, US-CA#123, JP-TOR#1)
+    # If left empty or commented out, the fastest P2P server will be chosen automatically.
+    # PROTONVPN_SERVER=NL-FREE#1
+
+    # Optional: Override default PUID/PGID if needed for file permissions on downloads
+    # PUID=1000
+    # PGID=1000
+    # TZ=America/New_York
+    ```
+    *   **This is the main configuration step you need to perform.**
+    *   For `PROTONVPN_SERVER`, you can leave it blank to automatically connect to the fastest P2P server, or specify one. Find server names via `protonvpn-cli servers` (once running) or the ProtonVPN website.
+
+3.  **Create Downloads Directory:**
+    This directory will store your downloaded files on the host machine.
+    ```bash
+    mkdir downloads
+    ```
+    *(If you change the PUID/PGID in `.env`, ensure this directory's ownership or permissions align if you encounter permission issues with downloaded files.)*
+
+## Usage
+
+1.  **Build and Start the Services:**
+    From the project directory (where `docker-compose.yml` is located):
+    ```bash
+    docker-compose up --build -d
+    ```
+    -   `--build`: Builds the custom Docker images the first time or if Dockerfiles change.
+    -   `-d`: Runs the containers in detached mode (in the background).
+    -   This might take a few minutes on the first run, especially on devices like a Raspberry Pi, as it builds the `protonvpn` image.
+
+2.  **Access qBittorrent Web UI:**
+    Once the `protonvpn` container is healthy and connected (see `docker-compose ps` or `docker-compose logs protonvpn`), you can access the qBittorrent Web UI at:
+    [http://localhost:9090](http://localhost:9090)
+    (Replace `localhost` with your Raspberry Pi's IP address if accessing from another device on your network).
+
+    Default qBittorrent credentials:
+    -   Username: `admin`
+    -   Password: `adminadmin`
+    **IMPORTANT: Change these default credentials immediately after your first login!** (Tools -> Options... -> Web UI tab)
+
+3.  **Check VPN Status & Logs:**
+    -   To see the status of your containers: `docker-compose ps`
+    -   To view logs for the ProtonVPN container (shows connection status, IP):
+        ```bash
+        docker-compose logs protonvpn
+        ```
+    -   To view logs for qBittorrent:
+        ```bash
+        docker-compose logs qbittorrent
+        ```
+
+4.  **Stopping the Services:**
+    ```bash
+    docker-compose down
+    ```
+    To stop and remove volumes (this will delete qBittorrent's configuration):
+    ```bash
+    docker-compose down -v
+    ```
+
+## Configuration Details
+
+-   **ARM64 (Raspberry Pi):** The `protonvpn/Dockerfile` uses an `arm64v8/ubuntu` base. The `linuxserver/qbittorrent` image is multi-arch, supporting ARM64.
+-   **Performance on Raspberry Pi:** While functional, performance (VPN speed, torrent processing) on Raspberry Pi will depend on the model, SD card speed, and network connection. Use a good quality power supply and consider an SSD for downloads for better performance.
+-   **ProtonVPN Server:** If `PROTONVPN_SERVER` in `.env` is empty, the `entrypoint.sh` script connects to the fastest P2P server using UDP.
+-   **qBittorrent Ports:**
+    -   Web UI: `9090`
+    -   Incoming P2P: `6881` (TCP/UDP). These are exposed through the VPN.
+-   **File Permissions:** The `PUID` and `PGID` environment variables (default to 1000) in `docker-compose.yml` (and overridable in `.env`) control the user under which qBittorrent runs. This affects file ownership in the `./downloads` directory. If your host user ID is different, you might want to adjust these. Find your user's ID with `id -u` and group ID with `id -g`.
+
+## Updating
+
+-   **To update qBittorrent (if a new `linuxserver/qbittorrent:latest` is out):**
+    ```bash
+    docker-compose pull qbittorrent
+    docker-compose up --build -d --remove-orphans
+    ```
+-   **To rebuild the `protonvpn` image (e.g., for OS updates or ProtonVPN CLI updates):**
+    ```bash
+    docker-compose build protonvpn
+    docker-compose up -d --remove-orphans
+    ```
+
+## Troubleshooting
+
+-   **ProtonVPN Connection Issues:**
+    -   Check `docker-compose logs protonvpn`.
+    -   Verify `PROTONVPN_USERNAME` and `PROTONVPN_PASSWORD` in `.env` are your OpenVPN/IKEv2 credentials.
+    -   Try a specific `PROTONVPN_SERVER` or leave it blank for automatic. Ensure the server supports P2P.
+    -   Ensure your ProtonVPN account is active.
+-   **qBittorrent Web UI Not Accessible at `http://localhost:9090`:**
+    -   Run `docker-compose ps`. Ensure `protonvpn` service is `healthy` and `qbittorrent` is `running`.
+    -   Check `docker-compose logs qbittorrent`.
+    -   Ensure no other service on your host is using port `9090`.
+-   **Permission Denied for `/dev/net/tun` (protonvpn container):**
+    -   This usually means the TUN module isn't loaded on the Docker host or Docker lacks permission.
+    -   On Linux hosts, try: `sudo modprobe tun`.
+    -   The `cap_add: [NET_ADMIN, SYS_MODULE]` and `devices: [/dev/net/tun:/dev/net/tun]` in `docker-compose.yml` should handle this on most systems.
+-   **Slow Speeds on Raspberry Pi:**
+    -   Use a wired Ethernet connection.
+    -   Ensure your Pi has adequate cooling.
+    -   Select a ProtonVPN server geographically close to you.
+    -   Limit the number of active torrents/connections in qBittorrent.
+
+## Security
+
+-   **Change qBittorrent Default Credentials!**
+-   Protect your `.env` file; it contains your VPN credentials. `chmod 600 .env`.
+-   The included `.gitignore` prevents committing `.env` by default.
+-   **Port Forwarding:** This setup does **not** handle automatic port forwarding from ProtonVPN to qBittorrent. For optimal seeding, port forwarding is beneficial. ProtonVPN's paid plans offer this. You'd need to configure it on the ProtonVPN website and then set that specific port in qBittorrent's listening port settings. This is an advanced step.
+
+Enjoy your secure and private qBittorrent setup!

--- a/protonvpn/entrypoint.sh
+++ b/protonvpn/entrypoint.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+echo "ProtonVPN Entrypoint Script Started"
+
+# Check if credentials are provided
+if [ -z "$PROTONVPN_USERNAME" ] || [ -z "$PROTONVPN_PASSWORD" ]; then
+  echo "Error: PROTONVPN_USERNAME and PROTONVPN_PASSWORD must be set as environment variables."
+  exit 1
+fi
+
+echo "Initializing ProtonVPN CLI and logging in..."
+# Attempt to initialize ProtonVPN.
+# The input '1' selects OpenVPN protocol.
+# Then username and password are provided.
+# Using sudo as the protonuser needs it for this command.
+# Adding error handling for init
+if ! sudo protonvpn init <<EOF
+1
+${PROTONVPN_USERNAME}
+${PROTONVPN_PASSWORD}
+EOF
+then
+  echo "ProtonVPN init failed. Please check credentials and if the CLI is working."
+  # Attempt to logout in case of partial previous session
+  sudo protonvpn logout || echo "Logout attempt failed or was not necessary."
+  # Retry init once after logout, as sometimes stale sessions can cause issues
+  echo "Retrying ProtonVPN init..."
+  if ! sudo protonvpn init <<EOF
+1
+${PROTONVPN_USERNAME}
+${PROTONVPN_PASSWORD}
+EOF
+  then
+    echo "ProtonVPN init failed on retry. Exiting."
+    exit 1
+  fi
+fi
+echo "ProtonVPN initialized successfully."
+
+
+# Determine server to connect to
+CONNECT_ARGS=""
+if [ -n "$PROTONVPN_SERVER" ]; then
+    echo "Connecting to specified ProtonVPN server: ${PROTONVPN_SERVER} (P2P)"
+    # Ensure --p2p is included if a specific server is named, assuming it's for P2P.
+    # The user should pick a P2P server if that's the intent.
+    # Most official server names don't need --p2p if they are already P2P optimized.
+    # However, protonvpn-cli connect <SERVER_NAME> --p2p is valid.
+    # Forcing protocol to OpenVPN UDP as it's generally good for performance/stability with torrents.
+    CONNECT_ARGS="${PROTONVPN_SERVER} --protocol udp"
+else
+    echo "Connecting to the fastest ProtonVPN P2P server with UDP protocol..."
+    CONNECT_ARGS="--p2p --fastest --protocol udp"
+fi
+
+# Connect to ProtonVPN
+echo "Attempting to connect: sudo protonvpn connect ${CONNECT_ARGS}"
+if ! sudo protonvpn connect ${CONNECT_ARGS}; then
+    echo "ProtonVPN connect command failed. Check server name or network."
+    # Try a more generic connection if specific one failed
+    echo "Attempting connection to fastest P2P server as a fallback..."
+    if ! sudo protonvpn connect --p2p --fastest --protocol udp; then
+        echo "Fallback ProtonVPN connection also failed. Exiting."
+        exit 1
+    fi
+fi
+
+echo "ProtonVPN connection established."
+echo "Verifying external IP address (will try a few sources):"
+external_ip=$(curl -s --max-time 10 ifconfig.me || curl -s --max-time 10 api.ipify.org || curl -s --max-time 10 checkip.amazonaws.com)
+if [ -n "$external_ip" ]; then
+    echo "External IP: $external_ip"
+else
+    echo "Could not fetch external IP. VPN might not be routing traffic correctly."
+fi
+echo ""
+
+# Keep the script running and monitor the VPN connection.
+while true; do
+  if sudo protonvpn status | grep -q -E "Connected to|Status: Connected"; then
+    current_time=$(date)
+    # echo "VPN Connection active at $current_time" # Can be verbose
+    # Let's check the IP periodically as well as a sanity check
+    # new_external_ip=$(curl -s --max-time 10 ifconfig.me)
+    # if [ "$new_external_ip" != "$external_ip" ] && [ -n "$new_external_ip" ]; then
+    #   echo "Warning: External IP changed from $external_ip to $new_external_ip at $current_time"
+    #   external_ip=$new_external_ip
+    # elif [ -z "$new_external_ip" ]; then
+    #   echo "Warning: Could not fetch external IP for check at $current_time"
+    # fi
+    sleep 60 # Check every 60 seconds
+  else
+    echo "ProtonVPN disconnected at $(date). Attempting to reconnect..."
+    if ! sudo protonvpn connect ${CONNECT_ARGS}; then
+        echo "Reconnect attempt with primary args failed. Trying fallback (fastest P2P)..."
+        if ! sudo protonvpn connect --p2p --fastest --protocol udp; then
+            echo "Fallback reconnect failed. Waiting 30s before retrying primary..."
+            sleep 30
+        else
+            echo "Reconnected with fallback server."
+            external_ip=$(curl -s --max-time 10 ifconfig.me || curl -s --max-time 10 api.ipify.org) # Update IP
+            echo "New External IP: $external_ip"
+        fi
+    else
+        echo "Reconnected with primary server/args."
+        external_ip=$(curl -s --max-time 10 ifconfig.me || curl -s --max-time 10 api.ipify.org) # Update IP
+        echo "New External IP: $external_ip"
+    fi
+  fi
+done
+
+# Fallback if the loop exits (it shouldn't).
+echo "Entrypoint script unexpected exit."


### PR DESCRIPTION
This commit sets up a Docker Compose project for running qBittorrent with all traffic routed through ProtonVPN.

Key changes and features:
- ARM64 Compatibility: Tailored for devices like Raspberry Pi (4B, 5+), using `arm64v8/ubuntu` for the ProtonVPN image. `linuxserver/qbittorrent` is multi-arch.
- qBittorrent Port Change: Web UI now accessible on port 9090 instead of 8080.
- Simplified Configuration: Uses an `.env` file for ProtonVPN credentials (OpenVPN/IKEv2 username/password) and optional server selection.
- Robust ProtonVPN Connection: Entrypoint script handles login, connection to fastest P2P server (or specified server) using UDP, and auto-reconnect.
- Healthchecks: `docker-compose.yml` includes a healthcheck for the `protonvpn` service to ensure VPN is active before `qbittorrent` service starts.
- Persistent Data: qBittorrent configuration is stored in a named Docker volume. Downloads are mapped to a local `./downloads` directory.
- Comprehensive Documentation: Updated `README.md` with detailed setup, usage, ARM64 considerations, and troubleshooting steps.
- Included `example.env` and a thorough `.gitignore`.

This provides a nearly plug-and-play setup once ProtonVPN credentials are provided in the .env file.